### PR TITLE
Fix curl_close

### DIFF
--- a/system/libraries/Request.php
+++ b/system/libraries/Request.php
@@ -704,7 +704,7 @@ class CI_Request
 	 */
 	public function close()
 	{
-		if (is_resource($this->curl)) {
+		if (is_resource($this->curl) && PHP_VERSION_ID < 80000) {
 			curl_close($this->curl);
 		}
 


### PR DESCRIPTION
While running the SDK on PHP 8.5 I’m seeing a deprecation warning originating from curl_close():

`Function curl_close() is deprecated since 8.5, as it has no effect since PHP 8.0`

This triggers every time the SDK makes a request.

From PHP 8.0 onward, cURL handles are automatically closed when they fall out of scope, and curl_close() no longer does anything. As of PHP 8.5 the function is formally deprecated.